### PR TITLE
Fix for add_label, encoding-awareness for labels

### DIFF
--- a/lib/gmail/client.rb
+++ b/lib/gmail/client.rb
@@ -157,7 +157,7 @@ module Gmail
     #     ...
     #   end
     def mailbox(name, &block)
-      name = name.to_s
+      name = Net::IMAP.encode_utf7(name.to_s)
       mailbox = (mailboxes[name] ||= Mailbox.new(self, name))
       switch_to_mailbox(name) if @current_mailbox != name
       if block_given?

--- a/lib/gmail/labels.rb
+++ b/lib/gmail/labels.rb
@@ -11,7 +11,7 @@ module Gmail
     # Get list of all defined labels.
     def all
       (conn.list("", "%")+conn.list("[Gmail]/", "%")).inject([]) do |labels,label|
-        label[:name].each_line {|l| labels << l }
+        label[:name].each_line {|l| labels << Net::IMAP.decode_utf7(l) }
         labels 
       end
     end
@@ -24,20 +24,20 @@ module Gmail
     
     # Returns +true+ when given label defined. 
     def exists?(label)
-      all.include?(label)
+      all.include?(Net::IMAP.encode_utf7(label))
     end
     alias :exist? :exists?
     
     # Creates given label in your account.
     def create(label)
-      !!conn.create(label) rescue false
+      !!conn.create(Net::IMAP.encode_utf7(label)) rescue false
     end
     alias :new :create
     alias :add :create
     
     # Deletes given label from your account. 
     def delete(label)
-      !!conn.delete(label) rescue false
+      !!conn.delete(Net::IMAP.encode_utf7(label)) rescue false
     end
     alias :remove :delete
     

--- a/lib/gmail/mailbox.rb
+++ b/lib/gmail/mailbox.rb
@@ -17,9 +17,11 @@ module Gmail
     }
   
     attr_reader :name
+    attr_reader :external_name
 
     def initialize(gmail, name="INBOX")
       @name  = name
+      @external_name = Net::IMAP.decode_utf7(name)
       @gmail = gmail
     end
 
@@ -97,7 +99,7 @@ module Gmail
     end
     
     def inspect
-      "#<Gmail::Mailbox#{'0x%04x' % (object_id << 1)} name=#{@name}>"
+      "#<Gmail::Mailbox#{'0x%04x' % (object_id << 1)} name=#{external_name}>"
     end
 
     def to_s

--- a/lib/gmail/message.rb
+++ b/lib/gmail/message.rb
@@ -94,7 +94,7 @@ module Gmail
     #
     # See also <tt>Gmail::Message#label!</tt>.
     def label(name, from=nil)
-      @gmail.mailbox(from || @mailbox.name) { @gmail.conn.uid_copy(uid, name) }
+      @gmail.mailbox(Net::IMAP.encode_utf7(from || @mailbox.external_name)) { @gmail.conn.uid_copy(uid, Net::IMAP.encode_utf7(name)) }
     rescue Net::IMAP::NoResponseError
       raise NoLabelError, "Label '#{name}' doesn't exist!"
     end
@@ -106,8 +106,8 @@ module Gmail
     def label!(name, from=nil)
       label(name, from) 
     rescue NoLabelError
-      @gmail.labels.add(name)
-      label!(name, from)
+      @gmail.labels.add(Net::IMAP.encode_utf7(name))
+      label(name, from)
     end
     alias :add_label :label!
     alias :add_label! :label!
@@ -119,7 +119,7 @@ module Gmail
     alias :delete_label! :remove_label!
     
     def inspect
-      "#<Gmail::Message#{'0x%04x' % (object_id << 1)} mailbox=#{@mailbox.name}#{' uid='+@uid.to_s if @uid}#{' message_id='+@message_id.to_s if @message_id}>"
+      "#<Gmail::Message#{'0x%04x' % (object_id << 1)} mailbox=#{@mailbox.external_name}#{' uid='+@uid.to_s if @uid}#{' message_id='+@message_id.to_s if @message_id}>"
     end
     
     def method_missing(meth, *args, &block)


### PR DESCRIPTION
Hi,

the first one is easy: add_label was not doing what the name suggested.

The second one is tough and needs a good review: Labels were outputted utf-7 to the user which is not a good idea, IMHO. I added the standard conversion methods at all places that I saw fitting - hopefully I didn't miss any. So: please review carefully.

I'm just seeing that two older commits are also in this pull request, I hope you don't mind :)
