### PR TITLE
Small fixes...

### DIFF
--- a/lib/gmail/client.rb
+++ b/lib/gmail/client.rb
@@ -3,7 +3,14 @@ module Gmail
     # Raised when connection with GMail IMAP service couldn't be established. 
     class ConnectionError < SocketError; end
     # Raised when given username or password are invalid.
-    class AuthorizationError < Net::IMAP::NoResponseError; end
+    class AuthorizationError < Net::IMAP::NoResponseError
+      if RUBY_VERSION >= "1.9.2"
+        def initialize(message)
+          response = Net::IMAP::ResponseText.new(message)
+          super(Net::IMAP::TaggedResponse.new(nil, nil, response, nil))
+        end
+      end
+    end
     # Raised when delivered email is invalid. 
     class DeliveryError < ArgumentError; end
     

--- a/lib/gmail/labels.rb
+++ b/lib/gmail/labels.rb
@@ -10,7 +10,7 @@ module Gmail
     
     # Get list of all defined labels.
     def all
-      (conn.list("", "%")+conn.list("[Gmail]/", "%")).inject([]) do |labels,label|
+      (conn.list("", "%")+conn.list("[Gmail]/", "%").to_a).inject([]) do |labels,label|
         label[:name].each_line {|l| labels << Net::IMAP.decode_utf7(l) }
         labels 
       end


### PR DESCRIPTION
Because the last time the change was so big, some small fix cannot be applied. So I make this branch just for it.
1. For Ruby 1.9.2, `Net::IMAP::NoResponseError#new` take a `Net::IMAP::TaggedResponse` object as argument, the error description will be put in a `Net::IMAP::ResponseText`. A `NoMethodError` would be raised for the old code.
2. For me `conn.list('[Gmail]/', '%')` will return `nil`, then an error would be raised since we cannot `+ nil`.
