### PR TITLE
Fix for XOAuth SMTP settings.  Expands on fix by jonpierce. 

### DIFF
--- a/lib/gmail/client/xoauth.rb
+++ b/lib/gmail/client/xoauth.rb
@@ -28,17 +28,30 @@ module Gmail
         raise_errors and raise AuthorizationError, "Couldn't login to given GMail account: #{username}"        
       end
 
+      def access_token
+        consumer_options = {
+          :site               => "https://www.google.com",
+          :request_token_path => "/accounts/OAuthGetRequestToken",
+          :authorize_path     => "/accounts/OAuthAuthorizeToken",
+          :access_token_path  => "/accounts/OAuthGetAccessToken"
+        }
+        consumer = OAuth::Consumer.new(consumer_key, consumer_secret, consumer_options)
+        @access_token ||= OAuth::AccessToken.new(consumer, token, secret)
+        @access_token
+      end
+
       def smtp_settings
         [:smtp, {
            :address => GMAIL_SMTP_HOST,
            :port => GMAIL_SMTP_PORT,
            :domain => mail_domain,
            :user_name => username,
-           :password => secret = {
+           :password => {
              :consumer_key    => consumer_key,
              :consumer_secret => consumer_secret,
              :token           => token,
-             :token_secret    => token_secret
+             :token_secret    => secret,
+             :access_token    => access_token
            },
            :authentication => :xoauth,
            :enable_starttls_auto => true


### PR DESCRIPTION
Fix for XOAuth SMTP settings.  Expands on fix by jonpierce.  Includes access token with consumer required for sending messages.

Hi,

I needed this modification to get sending messages to work with XOAuth.  I branched it off the v0.4.0 tag.

Regards,

- Marcel