### PR TITLE
Added Mutex.new statement to prevent deadlocking error

### DIFF
--- a/lib/gmail/client/base.rb
+++ b/lib/gmail/client/base.rb
@@ -151,6 +151,7 @@ module Gmail
       #     ...
       #   end
       def mailbox(name, &block)
+        @mailbox_mutex = Mutex.new
         @mailbox_mutex.synchronize do
           name = name.to_s
           mailbox = (mailboxes[name] ||= Mailbox.new(self, name))


### PR DESCRIPTION
Hi, in ruby 1.9, there were errors when I tried to use the gem.
internal:prelude:8:in `lock': deadlock; recursive locking (ThreadError)
I traced it to base.rb statement -  @mailbox_mutex.synchronize do
This does not make sense to me as it should be a mutex variable. I just made this into mutex variable and the errors went away. Thought this might be useful to others. 

thanks!
great Gem. very useful. thanks :)
