### PR TITLE
Adding the content-type text/html on multipart readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ email either, because ruby-gmail will set it for you.
         body "Text of plaintext message."
       end
       html_part do
+        content_type 'text/html; charset=UTF-8'
         body "<p>Text of <em>html</em> message.</p>"
       end
       add_file "/path/to/some_image.jpg"


### PR DESCRIPTION
The example was not working, now it does :)
