### PR TITLE
fixed rescue call in Rakefile to assign LoadError object

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ task :default => :test
 
 begin 
   require 'metric_fu'
-rescue LoadError
+rescue LoadError => e
   STDERR.puts e.message
   STDERR.puts "Run `gem install metric_fu` to install Metric-Fu"
 end


### PR DESCRIPTION
The diff pretty much explains it. `STDERR.puts e.message` fails with `undefined method `message' for nil:NilClass` because e isn't assigned in the rescue clause. Changed it to `rescue LoadError => e`
