### PR TITLE
Throw authorization errors the right way (fix for 1.9)

### DIFF
--- a/lib/gmail/client.rb
+++ b/lib/gmail/client.rb
@@ -3,7 +3,24 @@ module Gmail
     # Raised when connection with GMail IMAP service couldn't be established. 
     class ConnectionError < SocketError; end
     # Raised when given username or password are invalid.
-    class AuthorizationError < Net::IMAP::NoResponseError; end
+    class AuthorizationError < Net::IMAP::NoResponseError;
+      def self.initialize(response)
+        super(response) if response
+      end
+
+      def exception(message = nil)
+        return self if message == nil || message == self
+        return self if response # We already have a perfectly fine message, thank you very much
+
+        StandardError.instance_method(:initialize).bind(self).call(message.to_str)
+
+        self
+      end
+
+      def to_str
+        @message
+      end
+    end
     # Raised when delivered email is invalid. 
     class DeliveryError < ArgumentError; end
     # Raised when given client is not registered

--- a/lib/gmail/client/plain.rb
+++ b/lib/gmail/client/plain.rb
@@ -10,8 +10,8 @@ module Gmail
 
       def login(raise_errors=false)
         @imap and @logged_in = (login = @imap.login(username, password)) && login.name == 'OK'
-      rescue Net::IMAP::NoResponseError
-        raise_errors and raise AuthorizationError, "Couldn't login to given GMail account: #{username}"
+      rescue Net::IMAP::NoResponseError => e
+        raise_errors and raise AuthorizationError.new(e.response), "Couldn't login to given GMail account: #{username}", e.backtrace
       end
     end # Plain
 

--- a/lib/gmail/client/xoauth.rb
+++ b/lib/gmail/client/xoauth.rb
@@ -24,8 +24,10 @@ module Gmail
           :token           => token,
           :token_secret    => secret
         )) && login.name == 'OK'
-      rescue
-        raise_errors and raise AuthorizationError, "Couldn't login to given GMail account: #{username}"        
+      rescue Net::IMAP::NoResponseError => e
+        raise_errors and raise AuthorizationError.new(e.response), "Couldn't login to given GMail account: #{username}", e.backtrace
+      rescue => e
+        raise_errors and raise AuthorizationError.new(nil), "Couldn't login to given GMail account: #{username}", e.backtrace
       end
 
       def smtp_settings


### PR DESCRIPTION
The problem is that Net::IMAP::NoResponseError doesn't accept a string
but a response object. It then takes the message from this response
object.
Another problem (unrelated to 1.8/1.9) is that raising a different error
throws away information (message and backtrace). The error could be many
things (Too many connections, incorrect token, ...) so this hides a lot
of useful information.

The approach taken here is not tested on ruby 1.8.x and may not work
there.

This may also provide more info for issue #30
