### PR TITLE
Bugfix: Improperly processing labels containing parentheses

### DIFF
--- a/lib/gmail/client/imap_extensions.rb
+++ b/lib/gmail/client/imap_extensions.rb
@@ -36,7 +36,7 @@ module GmailImapExtensions
           # Gmail extension additions.
           # Cargo-Cult code warning: # I have no idea why the regexp - just copying a pattern
           when /\A(?:X-GM-LABELS)\z/ni
-            name, val = flags_data
+            name, val = x_gm_labels_data
           when /\A(?:X-GM-MSGID)\z/ni 
             name, val = uid_data
           when /\A(?:X-GM-THRID)\z/ni 
@@ -48,7 +48,97 @@ module GmailImapExtensions
         end
         return attr
       end
+
+      # Based on Net::IMAP#flags_data, but calling x_gm_labels_list to parse labels
+      def x_gm_labels_data
+        token = match(self.class::T_ATOM)
+        name = token.value.upcase
+        match(self.class::T_SPACE)
+        return name, x_gm_label_list
+      end
+
+      # Based on Net::IMAP#flag_list with a modified Regexp
+      # Labels are returned as escape-quoted strings
+      # We extract the labels using a regexp which extracts any unescaped strings
+      def x_gm_label_list
+        if @str.index(/\(([^)]*)\)/ni, @pos)
+          resp = extract_labels_response
+
+          # We need to manually update the position of the regexp to prevent trip-ups
+          @pos += resp.length
+          return resp.scan(/"([^"\\]*(?:\\.[^"\\]*)*)"/ni).flatten.collect(&:unescape)
+        else
+          parse_error("invalid label list")
+        end
+      end
+
+      # The way Gmail return tokens can cause issues with Net::IMAP's reader,
+      # so we need to extract this section manually
+      def extract_labels_response
+        special, quoted = false, false
+        index, paren_count = 0, 0
+
+        # Start parsing response string for the labels section, parentheses inclusive
+        labels_header = "X-GM-LABELS ("
+        start = @str.index(labels_header) + labels_header.length - 1
+        substr = @str[start..-1]
+        substr.each_char do |char|
+          index += 1
+          case char
+          when '('
+            paren_count += 1 unless quoted
+          when ')'
+            paren_count -= 1 unless quoted
+            break if paren_count == 0
+          when '"'
+            quoted = !quoted unless special
+          end
+          special = (char == '\\' && !special)
+        end
+        substr[0..index]
+      end
+    end # class_eval
+
+    # Add String#unescape
+    add_unescape
+  end # PNIRP
+
+  def self.add_unescape(klass = String)
+    klass.class_eval do
+      # Add a method to string which unescapes special characters
+      # We use a simple state machine to ensure that specials are not
+      # themselves escaped
+      def unescape
+        unesc = ''
+        special = false
+        escapes = { '\\' => '\\',
+                    '"'  => '"',
+                    'n' => "\n",
+                    't' => "\t",
+                    'r' => "\r",
+                    'f' => "\f",
+                    'v' => "\v",
+                    '0' => "\0",
+                    'a' => "\a"
+                  }
+
+        self.each_char do |char|
+          if special
+            # If in special mode, add in the replaced special char if there's a match
+            # Otherwise, add in the backslash and the current character
+            unesc << (escapes.keys.include?(char) ? escapes[char] : "\\#{char}")
+            special = false
+          else
+            # Toggle special mode if backslash is detected; otherwise just add character
+            if char == '\\'
+              special = true
+            else
+              unesc << char
+            end
+          end
+        end
+        unesc
+      end
     end
   end
-
 end


### PR DESCRIPTION
Gmail gem previously considered labels to be processable as flags. However, due to the way Net::IMAP's regexps are constructed, they do not handle parentheses within flag data properly (as described in #81).

This commit creates dedicated functions to process Gmail label data:
- Net::IMAP::ResponseParser#x_gm_labels_data is based on #flags_data, but calls the
  new function x_gm_label_list
- Net::IMAP::ResponseParser#x_gm_label_list is based on #flag_list, but uses an
  updated regexp which captures strings entirely, including nested parentheses
- String#unescape allows the client to unescape the label names, which are
  returned as escaped strings

As of writing, all specs still pass. No specs have been provided for the
unescaping code, as this was pulled from another project and is not core to
Gmail gem.
