### PR TITLE
add imap idle method to wait for new messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ pkg
 
 ## Test Account details
 spec/account.yml
+
+Gemfile.lock

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -73,6 +73,25 @@ describe "Gmail client (Plain)" do
         client.connection.should_not be_nil
       end
     end
+
+    it "should be able to wait for messages using IMAP idle" do
+      mock_client do |client|
+        t = Thread.new do
+          client.idle.should_not be nil
+        end
+
+        client.deliver do
+          to TEST_ACCOUNT[0]
+          subject "imap idle test"
+          text_part do 
+            body "hullo"
+          end
+        end
+
+        t.join
+      end
+    end
+    
     
     it "should properly compose message" do 
       mail = mock_client.compose do
@@ -134,7 +153,8 @@ describe "Gmail client (Plain)" do
         end
       end
     end
-    
+
+
     context "labels" do
       subject { 
         client = Gmail::Client::Plain.new(*TEST_ACCOUNT)


### PR DESCRIPTION
I added a small feature that uses IMAP IDLE, which has a method supporting it in the standard library IMAP implementation. I've written it to return when a new message is received, so you can use it to avoid repeatedly polling your inbox. You should also be able to pass a block that gets executed on new messages, but I didn't have time to write a test for it so I'm not sure if that bit works.

There's also the issue of IDLE timing out after 30 min, the code I adapted this from wraps the whole `imap.idle` block in a loop and has a separate thread that closes and reopens the connection -

````ruby
loop do
  Thread.new do
    puts "Starting timer"
    sleep 29 * 60
    imap.idle_done
  end
  
  imap.idle do |r|
     # etc
  end
end
````

but I'm not sure this is the best way to handle it, so I've left the timeout handling out here.