### PR TITLE
Remove broken/unused MIME dependency

### DIFF
--- a/lib/gmail/message.rb
+++ b/lib/gmail/message.rb
@@ -1,5 +1,3 @@
-require 'mime/message'
-
 module Gmail
   class Message
     # Raised when given label doesn't exists.


### PR DESCRIPTION
Currently, users **cannot use this gem** with bundle update as the `Mime` gem has changed its interface.
