### PR TITLE
Remove mail dependency version lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Or install it manually:
     cd gmail
     rake install
 
-To install gmail gem you have to met following requirements (with rubygems all 
-will be installed automatically):
+gmail gem has the following dependencies (with Bundler all will be installed automatically):
 
-* mail
+* mail (Ruby 1.8.7 users should lock mail gem version at 2.5.3)
 * mime
+* gmail_xoauth
 * smpt_tls (Ruby < 1.8.7)
 
 ## Features

--- a/gmail.gemspec
+++ b/gmail.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   
   # runtime dependencies
   s.add_dependency "mime", ">= 0.1"
-  s.add_dependency "mail", "2.5.3"
+  s.add_dependency "mail", ">= 2.2.1"
   s.add_dependency "gmail_xoauth", ">= 0.3.0"
   
   # development dependencies


### PR DESCRIPTION
This commit fixes dependency version clashes related to the `mail` gem. It rolls back commit a8197c5696972159888ec89e40d26324733f8460.
