### PR TITLE
Fixing incorrect method signature for msg_att

### DIFF
--- a/lib/gmail/client/imap_extensions.rb
+++ b/lib/gmail/client/imap_extensions.rb
@@ -4,7 +4,7 @@ module GmailImapExtensions
 
   def self.patch_net_imap_response_parser(klass = Net::IMAP::ResponseParser)
     klass.class_eval do
-      def msg_att
+      def msg_att(n)
         match(Net::IMAP::ResponseParser::T_LPAR)
         attr = {}
         while true
@@ -42,7 +42,7 @@ module GmailImapExtensions
           when /\A(?:X-GM-THRID)\z/ni 
             name, val = uid_data
           else
-            parse_error("unknown attribute `%s'", token.value)
+            parse_error("unknown attribute `%s' for {%d}", token.value, n)
           end
           attr[name] = val
         end


### PR DESCRIPTION
Otherwise, it crashes:

```
gmail = Gmail.connect(login, password)
eml = gmail.mailbox(folder_name).unread.first
 x = eml.attachments
```

was causing crash on wrong number of arguments.