### PR TITLE
Add gm raw support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ conversation/thread will come as a separate message.
 
     gmail.inbox.emails(:unread, :before => Date.parse("2010-04-20"), :from => "myboss@gmail.com")
 
+The [gm option](https://developers.google.com/gmail/imap_extensions?csw=1#extension_of_the_search_command_x-gm-raw) enables use of the Gmail search syntax.
+
+    gmail.inbox.emails(gm: '"testing"')
+
 You can use also one of aliases:
 
     gmail.inbox.find(...)

--- a/lib/gmail/mailbox.rb
+++ b/lib/gmail/mailbox.rb
@@ -58,6 +58,7 @@ module Gmail
         opts[:search]     and search.concat ['BODY', opts[:search]]
         opts[:body]       and search.concat ['BODY', opts[:body]]
         opts[:query]      and search.concat opts[:query]
+        opts[:gm]         and search.concat ['X-GM-RAW', opts[:gm]]
 
         @gmail.mailbox(name) do
           @gmail.conn.uid_search(search).collect do |uid| 


### PR DESCRIPTION
- [x-gm-raw docs](https://developers.google.com/gmail/imap_extensions?csw=1#extension_of_the_search_command_x-gm-raw)

gm raw has been on the [todo list](https://github.com/nu7hatch/gmail/commit/687bb4077a3b1a3caacdd7c069df01582e651d18) since 2012. [ruby-gmail](https://github.com/dcparker/ruby-gmail/blob/f8c2651f19cb41d9efb9029e01b281a609ffe32c/lib/gmail/mailbox.rb#L66) has supported it for a bit. It's a one line fix. I've added this feature to the gmail gem.