### PR TITLE
Update imap_extensions to match ruby 2.1 imap

### DIFF
--- a/lib/gmail/client/imap_extensions.rb
+++ b/lib/gmail/client/imap_extensions.rb
@@ -4,7 +4,7 @@ module GmailImapExtensions
 
   def self.patch_net_imap_response_parser(klass = Net::IMAP::ResponseParser)
     klass.class_eval do
-      def msg_att
+      def msg_att(n)
         match(Net::IMAP::ResponseParser::T_LPAR)
         attr = {}
         while true
@@ -42,7 +42,7 @@ module GmailImapExtensions
           when /\A(?:X-GM-THRID)\z/ni 
             name, val = uid_data
           else
-            parse_error("unknown attribute `%s'", token.value)
+            parse_error("unknown attribute `%s'", token.value, n)
           end
           attr[name] = val
         end


### PR DESCRIPTION
At some point ruby's imap `msg_att` method started received an argument, this makes the gem compliant.