### PR TITLE
Fix IMAP patch to work on Ruby 2

### DIFF
--- a/lib/gmail/client/imap_extensions.rb
+++ b/lib/gmail/client/imap_extensions.rb
@@ -3,52 +3,102 @@
 module GmailImapExtensions
 
   def self.patch_net_imap_response_parser(klass = Net::IMAP::ResponseParser)
-    klass.class_eval do
-      def msg_att
-        match(Net::IMAP::ResponseParser::T_LPAR)
-        attr = {}
-        while true
-          token = lookahead
-          case token.symbol
-          when Net::IMAP::ResponseParser::T_RPAR
-            shift_token
-            break
-          when Net::IMAP::ResponseParser::T_SPACE
-            shift_token
+
+    # https://github.com/ruby/ruby/blob/4d426fc2e03078d583d5d573d4863415c3e3eb8d/lib/net/imap.rb#L2258
+    if Net::IMAP::ResponseParser.new.method(:msg_att).arity == 1
+      klass.class_eval do
+        def msg_att(n)
+          match(Net::IMAP::ResponseParser::T_LPAR)
+          attr = {}
+          while true
             token = lookahead
+            case token.symbol
+              when Net::IMAP::ResponseParser::T_RPAR
+                shift_token
+                break
+              when Net::IMAP::ResponseParser::T_SPACE
+                shift_token
+                token = lookahead
+            end
+            case token.value
+              when /\A(?:ENVELOPE)\z/ni
+                name, val = envelope_data
+              when /\A(?:FLAGS)\z/ni
+                name, val = flags_data
+              when /\A(?:INTERNALDATE)\z/ni
+                name, val = internaldate_data
+              when /\A(?:RFC822(?:\.HEADER|\.TEXT)?)\z/ni
+                name, val = rfc822_text
+              when /\A(?:RFC822\.SIZE)\z/ni
+                name, val = rfc822_size
+              when /\A(?:BODY(?:STRUCTURE)?)\z/ni
+                name, val = body_data
+              when /\A(?:UID)\z/ni
+                name, val = uid_data
+
+              # Gmail extension additions.
+              # Cargo-Cult code warning: # I have no idea why the regexp - just copying a pattern
+              when /\A(?:X-GM-LABELS)\z/ni
+                name, val = flags_data
+              when /\A(?:X-GM-MSGID)\z/ni
+                name, val = uid_data
+              when /\A(?:X-GM-THRID)\z/ni
+                name, val = uid_data
+              else
+                parse_error("unknown attribute `%s' for {%d}", token.value, n)
+            end
+            attr[name] = val
           end
-          case token.value
-          when /\A(?:ENVELOPE)\z/ni
-            name, val = envelope_data
-          when /\A(?:FLAGS)\z/ni
-            name, val = flags_data
-          when /\A(?:INTERNALDATE)\z/ni
-            name, val = internaldate_data
-          when /\A(?:RFC822(?:\.HEADER|\.TEXT)?)\z/ni
-            name, val = rfc822_text
-          when /\A(?:RFC822\.SIZE)\z/ni
-            name, val = rfc822_size
-          when /\A(?:BODY(?:STRUCTURE)?)\z/ni
-            name, val = body_data
-          when /\A(?:UID)\z/ni
-            name, val = uid_data
-      
-          # Gmail extension additions.
-          # Cargo-Cult code warning: # I have no idea why the regexp - just copying a pattern
-          when /\A(?:X-GM-LABELS)\z/ni
-            name, val = flags_data
-          when /\A(?:X-GM-MSGID)\z/ni 
-            name, val = uid_data
-          when /\A(?:X-GM-THRID)\z/ni 
-            name, val = uid_data
-          else
-            parse_error("unknown attribute `%s'", token.value)
-          end
-          attr[name] = val
+          return attr
         end
-        return attr
+      end
+    else
+      klass.class_eval do
+        def msg_att
+          match(Net::IMAP::ResponseParser::T_LPAR)
+          attr = {}
+          while true
+            token = lookahead
+            case token.symbol
+              when Net::IMAP::ResponseParser::T_RPAR
+                shift_token
+                break
+              when Net::IMAP::ResponseParser::T_SPACE
+                shift_token
+                token = lookahead
+            end
+            case token.value
+              when /\A(?:ENVELOPE)\z/ni
+                name, val = envelope_data
+              when /\A(?:FLAGS)\z/ni
+                name, val = flags_data
+              when /\A(?:INTERNALDATE)\z/ni
+                name, val = internaldate_data
+              when /\A(?:RFC822(?:\.HEADER|\.TEXT)?)\z/ni
+                name, val = rfc822_text
+              when /\A(?:RFC822\.SIZE)\z/ni
+                name, val = rfc822_size
+              when /\A(?:BODY(?:STRUCTURE)?)\z/ni
+                name, val = body_data
+              when /\A(?:UID)\z/ni
+                name, val = uid_data
+
+              # Gmail extension additions.
+              # Cargo-Cult code warning: # I have no idea why the regexp - just copying a pattern
+              when /\A(?:X-GM-LABELS)\z/ni
+                name, val = flags_data
+              when /\A(?:X-GM-MSGID)\z/ni
+                name, val = uid_data
+              when /\A(?:X-GM-THRID)\z/ni
+                name, val = uid_data
+              else
+                parse_error("unknown attribute `%s'", token.value)
+            end
+            attr[name] = val
+          end
+          return attr
+        end
       end
     end
   end
-
 end

--- a/spec/imap_spec.rb
+++ b/spec/imap_spec.rb
@@ -1,0 +1,15 @@
+require 'rubygems'
+require 'rspec'
+require 'net/imap'
+require 'gmail/client/imap_extensions'
+
+describe 'imap patch' do
+
+  it 'should not modify arity' do
+    old_arity = Net::IMAP::ResponseParser.new.method(:msg_att).arity
+    GmailImapExtensions::patch_net_imap_response_parser
+    new_arity = Net::IMAP::ResponseParser.new.method(:msg_att).arity
+
+    expect(old_arity).to eq(new_arity)
+  end
+end


### PR DESCRIPTION
This is different from the other PRs in a few ways:

- Test runs on travis to verify Ruby 1.9.3 and 2.1.5 work
- Patch is conditional on arity